### PR TITLE
Standardize current_queues import

### DIFF
--- a/invenio_queues/__init__.py
+++ b/invenio_queues/__init__.py
@@ -11,6 +11,7 @@
 from __future__ import absolute_import, print_function
 
 from .ext import InvenioQueues
+from .proxies import current_queues
 from .version import __version__
 
 __all__ = (

--- a/tests/test_invenio_queues.py
+++ b/tests/test_invenio_queues.py
@@ -11,16 +11,13 @@
 from __future__ import absolute_import, print_function
 
 import pytest
-from click.testing import CliRunner
-from conftest import MOCK_MQ_EXCHANGE, mock_iter_entry_points_factory, \
-    remove_queues
+from conftest import MOCK_MQ_EXCHANGE, mock_iter_entry_points_factory
 from flask import Flask
 from mock import patch
 from pkg_resources import EntryPoint
 
-from invenio_queues import InvenioQueues
+from invenio_queues import InvenioQueues, current_queues
 from invenio_queues.errors import DuplicateQueueError
-from invenio_queues.proxies import current_queues
 
 
 def test_version():


### PR DESCRIPTION
Makes it so that

```python
from invenio_queues import current_queues
```

works like other invenio modules.

(also cleanup unused imports in test)