### PR TITLE
travis: set dist to trusty

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -21,6 +21,7 @@
 # In applying this license, CERN does not
 # waive the privileges and immunities granted to it by virtue of its status
 # as an Intergovernmental Organization or submit itself to any jurisdiction.
+dist: trusty
 
 notifications:
   email: false
@@ -48,6 +49,7 @@ python:
   - "3.5"
 
 before_install:
+  - "pip install --upgrade pip"
   - "nvm install 6; nvm use 6"
   - "travis_retry pip install --upgrade pip setuptools py"
   - "travis_retry pip install twine wheel coveralls requirements-builder"

--- a/invenio_queues/queue.py
+++ b/invenio_queues/queue.py
@@ -29,8 +29,8 @@ from __future__ import absolute_import, print_function
 from contextlib import contextmanager
 
 from amqp.exceptions import ChannelError, NotFound
-from kombu import Queue as Q
 from kombu import Producer
+from kombu import Queue as Q
 from kombu.compat import Consumer
 from werkzeug.utils import cached_property
 

--- a/setup.py
+++ b/setup.py
@@ -34,13 +34,13 @@ history = open('CHANGES.rst').read()
 tests_require = [
     'check-manifest>=0.25',
     'coverage>=4.0',
-    'isort>=4.2.2',
+    'isort>=4.3.21',
     'mock>=1.0.0',
     'pydocstyle>=1.0.0',
     'pytest-cache>=1.0',
     'pytest-cov>=1.8.0',
     'pytest-pep8>=1.0.6',
-    'pytest>=2.8.0',
+    'pytest>=3.8.1,<4',
 ]
 
 extras_require = {


### PR DESCRIPTION
* Fixes the rabbitmq server in travis by setting the
  dist used to trusty.

Signed-off-by: dinos <dinos.simpson@gmail.com>