### PR TITLE
amqp version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -62,7 +62,6 @@ install_requires = [
     'Flask>=0.11',
     'kombu>=4.0.2,<5.0',
     'redis>=2.10.0',
-    'amqp>=2.1.4',
 ]
 
 packages = find_packages()


### PR DESCRIPTION
Our installations fail with 
`ERROR: kombu 4.6.5 has requirement amqp==2.5.1, but you'll have amqp 2.5.2 which is incompatible.`

Removed the explicit amqp requirement. The same requirement appears in `kombu` `4.0.2` version, and if we re-introduce it breaks pip dependencies resolution.