### PR TITLE
fix(ext): make `current_queues.queues` property thread-safe

### DIFF
--- a/invenio_queues/ext.py
+++ b/invenio_queues/ext.py
@@ -30,7 +30,7 @@ class _InvenioQueuesState(object):
     @cached_property
     def queues(self):
         if self._queues is None:
-            self._queues = dict()
+            queues = dict()
             from_entry_point = [
                 ep.load()() for ep in entry_points(group=self.entry_point_group)
             ]
@@ -39,14 +39,16 @@ class _InvenioQueuesState(object):
                 from_entry_point, [self.app.config["QUEUES_DEFINITIONS"]]
             ):
                 for cfg in queue:
-                    if cfg["name"] in self._queues:
+                    if cfg["name"] in queues:
                         raise DuplicateQueueError(
                             "Duplicate queue {0} found".format(cfg["name"])
                         )
 
-                    self._queues[cfg["name"]] = Queue(
+                    queues[cfg["name"]] = Queue(
                         cfg["exchange"], cfg["name"], self.connection_pool
                     )
+
+            self._queues = queues
 
         return self._queues
 

--- a/tests/test_invenio_queues.py
+++ b/tests/test_invenio_queues.py
@@ -58,6 +58,8 @@ def test_duplicate_queue(app, MockEntryPoint):
         with patch("importlib.metadata.entry_points", entrypoints):
             with pytest.raises(DuplicateQueueError):
                 current_queues.queues()
+            assert current_queues._queues is None
+            assert "queues" not in current_queues.__dict__
 
 
 with_different_brokers = pytest.mark.parametrize(


### PR DESCRIPTION
* Because we were setting `self._queues = {}` early in the
  `_InvenioQueuesState.queues` property, concurrent callers would be
  returning early without having any queues loaded, thus often ending up
  with a `KeyError` while the actual `self._queues` was being loaded.
  By setting the `self._queues` attribute after computing the queues, we
  avoid this race-condition, and might only be affected by multiple
  concurrent initializers (which is not that bad in terms of
  correctness).
